### PR TITLE
优化IOS里的长按和滑动记录命令

### DIFF
--- a/lib/units/ios-device/plugins/touch/index.js
+++ b/lib/units/ios-device/plugins/touch/index.js
@@ -23,6 +23,7 @@ module.exports = syrup.serial()
   .define(function(options, wda, router, display, flags) {
     var log = logger.createLogger('ios-device:plugins:touch')
     var touchTime = 0
+    var lastMoveTime = 0
     var bIsTouch = false
     var startX = 0
     var startY = 0
@@ -90,6 +91,7 @@ module.exports = syrup.serial()
     TouchConsumer.prototype.touchDown = function(point) {
       this.bTouchUp = false
       touchTime = Date.now()
+      lastMoveTime = touchTime
       this.touchCount+=1
       startX = point.x * this.width
       startY = point.y * this.height
@@ -108,17 +110,10 @@ module.exports = syrup.serial()
       endY = point.y * this.height
       if(Math.abs(startX - endX) < 10 && Math.abs(startY - endY) < 10) {
         //移动点小于10个像素,认为是在同一个点
-        if(Date.now()-touchTime<3000 && Date.now()-touchTime>=1000){
+        if(Date.now()-touchTime>=10000){
           //同一个像素点停留1.5s-3s,则认为是drag事件
           this.bDrag = true
           bIsTouch = false
-        }
-        else if(Date.now()-touchTime>3000){
-          //同一个像素点停留3s以上,则认为是longpress事件
-          if(!this.bTouchUp){
-            bIsTouch = false
-            wda.click(startX, startY, 2)
-          }
         }
       }
       else{
@@ -130,9 +125,10 @@ module.exports = syrup.serial()
         // endX = val.x
         // endY = val.y
         // log.info("end point:" + endX + " " + endY)
-        swipeList.push({x: endX, y: endY})
+        swipeList.push({x: endX, y: endY, t:Date.now() - lastMoveTime})
         preMovePoint.x = endX
         preMovePoint.y = endY
+        lastMoveTime = Date.now()
       }
     }
 
@@ -141,16 +137,13 @@ module.exports = syrup.serial()
       if(this.bDrag){
         //drag事件且移动距离超过50像素
         if(Math.abs(startX - endX) > 50 || Math.abs(startY - endY) > 50){
-          wda.drag(startX,startY,endX,endY,0.5)
+          wda.drag(startX, startY, endX, endY,0.5)
           this.bIsMove =false
         }
       }
       if(this.bIsMove) {
-        var dur = Date.now() - touchTime
-        var duration = dur * 50 / 100
-        if (duration > 2000) {
-          duration = 2000
-        }
+        var duration = Date.now() - touchTime
+        swipeList.push({x: endX, y: endY, t:Date.now() - lastMoveTime})
         if (duration < 50) {
           duration = 50
         }
@@ -159,7 +152,16 @@ module.exports = syrup.serial()
         wda.swipe(swipeList, duration)
       }
       else if(bIsTouch) {
-        wda.click(startX, startY, 0)
+        var duration = Date.now() - touchTime
+        eX = point.x * this.width
+        eY = point.y * this.height
+        if(duration > 1000 ){
+          swipeList.push({x: startX+5, y: startY+5, t: duration})
+          swipeList.unshift({x: startX, y: startY})
+          wda.swipe(swipeList, duration)
+        }else{
+          wda.click(startX, startY, 0)
+        }
        }
       this.touchReset()
     }

--- a/lib/units/ios-device/plugins/wdaCommands.js
+++ b/lib/units/ios-device/plugins/wdaCommands.js
@@ -69,7 +69,7 @@ module.exports = syrup.serial()
                 {
                     action:"wait",
                     options:{
-                        ms:time
+                        ms:swipeList[i].t
                     }
                 }
             )


### PR DESCRIPTION
原代码无法实现长按、游戏里的长时间拉拽摇杆等操作，故作出以下修改：
1、优化对LongPress,dray,swipe的判断； 
2、通过Wait实现长按操作； 
2、记录每次滑动之间的时间间隔，以便更好地模拟实际滑动操作