### PR TITLE
优化获取文件后缀名方法，修改重复安装STF服务问题

### DIFF
--- a/lib/units/device/resources/service.js
+++ b/lib/units/device/resources/service.js
@@ -17,7 +17,7 @@ module.exports = syrup.serial()
       pathutil.vendor('STFService/wire.proto'))
 
     var resource = {
-      requiredVersion: '2.4.2'
+      requiredVersion: '2.4.3'
     , pkg: 'jp.co.cyberagent.stf'
     , main: 'jp.co.cyberagent.stf.Agent'
     , apk: pathutil.vendor('STFService/STFService.apk')

--- a/lib/units/storage/temp.js
+++ b/lib/units/storage/temp.js
@@ -82,6 +82,10 @@ module.exports = function(options) {
           })
       })
   })
+  function catchtype(source) {
+    var typestr = source.toLowerCase().substring(source.lastIndexOf('.') + 1)
+    return typestr
+  }
 
   app.post('/s/upload/:plugin', function(req, res) {
     var form = new formidable.IncomingForm({
@@ -92,7 +96,10 @@ module.exports = function(options) {
     }
     form.on('fileBegin', function(name, file) {
       var md5 = crypto.createHash('md5')
-      file.name = md5.update(file.name).digest('hex')+"."+file.name.split('.')[1]
+      var myfilename = catchtype(file.name)
+      log.info('输出文件后缀名', myfilename)
+      file.name = md5.update(file.name).digest('hex') + '.' + myfilename
+      log.info('输出文件名', file.name)
     })
     Promise.promisify(form.parse, form)(req)
       .spread(function(fields, files) {


### PR DESCRIPTION
如果上传的文件名中有多个“.” 会获取不到后缀名，导致生成的临时文件名后缀不对，安装会报错，引起服务器奔溃